### PR TITLE
Fix adding styles on top when preserving order

### DIFF
--- a/src/style-implant.ts
+++ b/src/style-implant.ts
@@ -20,13 +20,12 @@ const styleImplant = (
     if (head.firstChild) {
       if (preserveOrder) {
         // Find the first child that isn't an implanted style tag
-        const firstNonImplant = Array.from(head.children).find(child => {
-          return child.getAttribute('data-style-implant') === null;
-        });
-        if (firstNonImplant) {
-          head.insertBefore(style, firstNonImplant as Node);
+        const firstImplant =
+          document.querySelector<HTMLStyleElementExtended>('[data-style-implant]');
+        if (firstImplant) {
+          firstImplant.insertAdjacentElement('afterend', style);
         } else {
-          head.appendChild(style);
+          head.insertBefore(style, head.firstChild);
         }
       } else {
         head.insertBefore(style, head.firstChild);

--- a/tests/style-implant.test.ts
+++ b/tests/style-implant.test.ts
@@ -150,6 +150,46 @@ describe('style-implant unit tests', async (): void => {
     expect(testElementColor).is.equal('rgb(0, 0, 255)');
   });
 
+  it('insert at top should let already exisiting styles in the html override the injected style when not preserving order', async (): void => {
+    await reloadPage();
+    // html page already has a style tag with color green
+    await page.evaluate(() => {
+      const style = document.createElement('style');
+      style.innerHTML = '.test{color: green;}';
+      style.type = 'text/css';
+      const head = document.head;
+      head.insertBefore(style, head.firstChild);
+      return;
+    });
+    await addImplants([
+      { css: '.test{color: red;}', options: { insertAt: 'top' } },
+      { css: '.test{color: blue;}', options: { insertAt: 'top' } },
+    ]);
+    const testElementColor = await getTestColor();
+    // Color should be blue because the second implant is added after the first as preserveOrder is enabled
+    expect(testElementColor).is.equal('rgb(0, 128, 0)');
+  });
+
+  it('insert at top should let already exisiting styles in the html override the injected style when preserving order', async (): void => {
+    await reloadPage();
+    // html page already has a style tag with color green
+    await page.evaluate(() => {
+      const style = document.createElement('style');
+      style.innerHTML = '.test{color: green;}';
+      style.type = 'text/css';
+      const head = document.head;
+      head.insertBefore(style, head.firstChild);
+      return;
+    });
+    await addImplants([
+      { css: '.test{color: red;}', options: { insertAt: 'top', preserveOrder: true } },
+      { css: '.test{color: blue;}', options: { insertAt: 'top', preserveOrder: true } },
+    ]);
+    const testElementColor = await getTestColor();
+    // Color should be blue because the second implant is added after the first as preserveOrder is enabled
+    expect(testElementColor).is.equal('rgb(0, 128, 0)');
+  });
+
   after(async (): void => {
     await page.close();
     await browser.close();


### PR DESCRIPTION
The original [style-inject](https://github.com/egoist/style-inject) had the option to inject styles on top of the head, this would be very useful for a component library, that allows user applications to overwrite their styles without a need for special setup in their application or using `!important` in styles.

The same behaviour works here when `preserveOrder` is set to `false` which would work exactly like style-inject. (Unit test added as an example)

The case with `preserveOrder: true` is that it wasn't doing the exact same thing, it would add the styles on the bottom of the `head` section, so when there are other styles, the would be overwritten by this injected (implanted) style. By preserving order of injection, the place of injection should not be changed. This pull request is aiming to fix that. (Unit test is added for this case too)